### PR TITLE
Decouple weather extraction and fix mart export bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ profiles.yml
 # Secrets and config
 *.toml
 !railway.toml
+!railway-weather.toml
 !.streamlit/config.toml
 secrets.*
 config/secrets.*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Weather Extraction Service** - Decoupled weather extraction from the monthly pipeline into a standalone entrypoint (`scripts/weather_entrypoint.sh`) with dedicated Railway config (`railway-weather.toml`) for independent 6-hour cron scheduling, enabling near-real-time weather data for dashboard recommendations
+
 ### Changed
 - **dbt Views Conversion** - Converted staging, intermediate, and unified dbt models from incremental tables to views, eliminating 23+ hour full-refresh hangs on 216M+ row datasets; marts remain as physical tables
+
+### Fixed
+- **Missing Mart Export** - Added `mart_similar_day_stats` to the `MART_TABLES` export list in `db_duckdb/operations.py`, fixing the mart never being exported to S3 despite dbt producing it
 
 ### Improved
 - **Insight Card Styling** - Neutral/info cards get subtle blue tint and all cards get colored left border matching severity (green/blue/amber/red)

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,6 @@ ENV DUCKDB_MEMORY_LIMIT=8GB
 ENV DUCKDB_THREADS=2
 
 # Make entrypoint executable
-RUN chmod +x scripts/railway_entrypoint.sh
+RUN chmod +x scripts/railway_entrypoint.sh scripts/weather_entrypoint.sh
 
 ENTRYPOINT ["scripts/railway_entrypoint.sh"]

--- a/db_duckdb/operations.py
+++ b/db_duckdb/operations.py
@@ -462,6 +462,7 @@ class DuckDBOperations:
             'mart_weather_impact_summary',
             'mart_station_directory',
             'mart_station_weather_performance',
+            'mart_similar_day_stats',
         ]
         
         # Intermediate and unified tables (optional exports)

--- a/railway-weather.toml
+++ b/railway-weather.toml
@@ -1,0 +1,8 @@
+[build]
+builder = "DOCKERFILE"
+dockerfilePath = "Dockerfile"
+
+[deploy]
+restartPolicyType = "NEVER"
+cronSchedule = "0 */6 * * *"
+startCommand = "scripts/weather_entrypoint.sh"

--- a/scripts/weather_entrypoint.sh
+++ b/scripts/weather_entrypoint.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "========================================"
+echo "City Cycles - Weather Extraction"
+echo "Started at: $(date -u '+%Y-%m-%d %H:%M:%S UTC')"
+echo "========================================"
+
+python -m orchestrator.cli stage weather_extraction && EXIT_CODE=0 || EXIT_CODE=$?
+
+echo "========================================"
+echo "Finished at: $(date -u '+%Y-%m-%d %H:%M:%S UTC')"
+echo "Exit code: $EXIT_CODE"
+echo "========================================"
+
+exit $EXIT_CODE


### PR DESCRIPTION
## Summary
- **Weather extraction service** — New standalone entrypoint (`scripts/weather_entrypoint.sh`) and Railway config (`railway-weather.toml`) for independent 6-hour cron scheduling, enabling near-real-time weather data for dashboard recommendations
- **Export bug fix** — Added `mart_similar_day_stats` to the `MART_TABLES` export list in `db_duckdb/operations.py`, fixing the mart never being exported to S3
- **Dockerfile** — Both entrypoint scripts are now `chmod +x` in the image

## Post-merge Railway setup
1. `railway add --service "weather-extraction" --repo "chrisrogers37/city-cycles"`
2. Set config file path to `/railway-weather.toml` in service settings
3. Link shared env vars (`AWS_*`, `S3_BUCKET`, `WEATHER_API_KEY`)

## Test plan
- [x] All 330 tests pass, 3 skipped
- [x] `mart_similar_day_stats` present in MART_TABLES list
- [x] `railway-weather.toml` has correct cron (`0 */6 * * *`) and start command
- [ ] After deploy: verify weather-extraction service fires independently on Railway

🤖 Generated with [Claude Code](https://claude.com/claude-code)