### PR TITLE
Replace BikingScore with weather-driven narrative

### DIFF
--- a/frontend/src/components/weather/WeatherNarrative.tsx
+++ b/frontend/src/components/weather/WeatherNarrative.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import type { CurrentWeatherResponse, SimilarDayResponse, RecommendationResponse, TempUnit } from "@/lib/types";
 import { formatHour12 } from "@/lib/format";
 import { useCityStore } from "@/store/useCityStore";
@@ -26,7 +26,6 @@ function buildNarrative(
   const desc = weather.weather_description.toLowerCase();
   const lines: string[] = [];
 
-  // Opening line — weather description
   const temp = Math.round(tempUnit === "fahrenheit" ? weather.temperature_f : weather.temperature_c);
   const unit = tempUnit === "fahrenheit" ? "F" : "C";
   lines.push(
@@ -99,10 +98,7 @@ export default function WeatherNarrative({
   const ready = !isLoading && !!weather;
 
   useEffect(() => {
-    if (!ready) {
-      // Reset handled via cleanup — no setState in effect body
-      return;
-    }
+    if (!ready) return;
     const id = setTimeout(() => setFadeIn(true), 100);
     return () => {
       clearTimeout(id);
@@ -112,7 +108,13 @@ export default function WeatherNarrative({
 
   const visible = ready && fadeIn;
 
-  if (isLoading || !weather) {
+  const narrative = useMemo(
+    () => weather ? buildNarrative(weather, similarDay, tempUnit).join(" ") : "",
+    [weather, similarDay, tempUnit],
+  );
+  const tagline = useMemo(() => pickTagline(recommendations), [recommendations]);
+
+  if (!ready) {
     return (
       <div className="flex flex-col items-center max-w-md mx-auto">
         <div className="space-y-3 w-full">
@@ -124,9 +126,6 @@ export default function WeatherNarrative({
     );
   }
 
-  const lines = buildNarrative(weather, similarDay, tempUnit);
-  const tagline = pickTagline(recommendations);
-
   return (
     <div
       className={`flex flex-col items-center max-w-lg mx-auto px-6 transition-all duration-700 ${
@@ -137,12 +136,7 @@ export default function WeatherNarrative({
         className="text-center text-base/relaxed text-white/75 font-light"
         style={{ textShadow: "0 1px 12px rgba(0,0,0,0.4)" }}
       >
-        {lines.map((line, i) => (
-          <span key={i}>
-            {i > 0 && " "}
-            {line}
-          </span>
-        ))}
+        {narrative}
       </p>
 
       {tagline && (

--- a/frontend/src/components/weather/WeatherNarrative.tsx
+++ b/frontend/src/components/weather/WeatherNarrative.tsx
@@ -94,18 +94,23 @@ export default function WeatherNarrative({
   isLoading,
 }: Props) {
   const tempUnit = useCityStore((s) => s.tempUnit);
-  const [visible, setVisible] = useState(false);
+  const [fadeIn, setFadeIn] = useState(false);
 
   const ready = !isLoading && !!weather;
 
   useEffect(() => {
     if (!ready) {
-      setVisible(false);
+      // Reset handled via cleanup — no setState in effect body
       return;
     }
-    const id = setTimeout(() => setVisible(true), 100);
-    return () => clearTimeout(id);
+    const id = setTimeout(() => setFadeIn(true), 100);
+    return () => {
+      clearTimeout(id);
+      setFadeIn(false);
+    };
   }, [ready]);
+
+  const visible = ready && fadeIn;
 
   if (isLoading || !weather) {
     return (

--- a/frontend/src/components/weather/WeatherNarrative.tsx
+++ b/frontend/src/components/weather/WeatherNarrative.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import type { CurrentWeatherResponse, SimilarDayResponse, RecommendationResponse } from "@/lib/types";
+import { formatHour12 } from "@/lib/format";
+
+const CITY_NAMES: Record<string, string> = {
+  nyc: "New York City",
+  london: "London",
+};
+
+interface Props {
+  weather: CurrentWeatherResponse | undefined;
+  similarDay: SimilarDayResponse | undefined;
+  recommendations: RecommendationResponse[] | undefined;
+  isLoading: boolean;
+}
+
+function buildNarrative(
+  weather: CurrentWeatherResponse,
+  similarDay: SimilarDayResponse | undefined,
+): string[] {
+  const cityName = CITY_NAMES[weather.city] ?? weather.city;
+  const desc = weather.weather_description.toLowerCase();
+  const lines: string[] = [];
+
+  // Opening line — weather description
+  const temp = Math.round(weather.temperature_f);
+  lines.push(
+    `It's ${desc} and ${temp}°F in ${cityName} right now.`,
+  );
+
+  // Duration insight
+  if (similarDay?.avg_duration_minutes != null) {
+    const dur = Math.round(similarDay.avg_duration_minutes);
+    const qualifier =
+      similarDay.duration_pct_change_vs_overall != null
+        ? similarDay.duration_pct_change_vs_overall > 5
+          ? " — longer than usual"
+          : similarDay.duration_pct_change_vs_overall < -5
+            ? " — shorter than usual"
+            : ""
+        : "";
+    lines.push(
+      `On days like this, bike rides tend to last around ${dur} minutes${qualifier}.`,
+    );
+  }
+
+  // Volume + peak hours
+  if (similarDay?.avg_daily_rides != null) {
+    const rides = Math.round(similarDay.avg_daily_rides).toLocaleString("en-US");
+    const pctDir =
+      similarDay.pct_change_vs_overall != null
+        ? Math.abs(similarDay.pct_change_vs_overall) >= 3
+          ? similarDay.pct_change_vs_overall > 0
+            ? `, about ${Math.abs(Math.round(similarDay.pct_change_vs_overall))}% more than average`
+            : `, about ${Math.abs(Math.round(similarDay.pct_change_vs_overall))}% fewer than average`
+          : ""
+        : "";
+
+    let peakInfo = "";
+    if (similarDay.peak_hour_start != null && similarDay.peak_hour_end != null) {
+      peakInfo = ` Peak activity hits between ${formatHour12(similarDay.peak_hour_start)} and ${formatHour12(similarDay.peak_hour_end)}.`;
+    }
+
+    lines.push(
+      `The city averages ${rides} rides in similar weather${pctDir}.${peakInfo}`,
+    );
+  }
+
+  return lines;
+}
+
+function pickTagline(recommendations: RecommendationResponse[] | undefined): string | null {
+  if (!recommendations?.length) return null;
+  // Find a positive or caution recommendation for a snappy closing line
+  const positive = recommendations.find((r) => r.severity === "positive");
+  if (positive) return positive.text;
+  const caution = recommendations.find((r) => r.severity === "caution");
+  if (caution) return caution.text;
+  return null;
+}
+
+export default function WeatherNarrative({
+  weather,
+  similarDay,
+  recommendations,
+  isLoading,
+}: Props) {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    if (!isLoading && weather) {
+      const id = setTimeout(() => setVisible(true), 100);
+      return () => clearTimeout(id);
+    }
+    setVisible(false);
+  }, [isLoading, weather]);
+
+  if (isLoading || !weather) {
+    return (
+      <div className="flex flex-col items-center max-w-md mx-auto">
+        <div className="space-y-3 w-full">
+          <div className="h-4 bg-white/5 rounded animate-pulse w-4/5 mx-auto" />
+          <div className="h-4 bg-white/5 rounded animate-pulse w-3/5 mx-auto" />
+          <div className="h-4 bg-white/5 rounded animate-pulse w-2/3 mx-auto" />
+        </div>
+      </div>
+    );
+  }
+
+  const lines = buildNarrative(weather, similarDay);
+  const tagline = pickTagline(recommendations);
+
+  return (
+    <div
+      className={`flex flex-col items-center max-w-lg mx-auto px-6 transition-all duration-700 ${
+        visible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-4"
+      }`}
+    >
+      <p
+        className="text-center text-base/relaxed text-white/75 font-light"
+        style={{ textShadow: "0 1px 12px rgba(0,0,0,0.4)" }}
+      >
+        {lines.map((line, i) => (
+          <span key={i}>
+            {i > 0 && " "}
+            {line}
+          </span>
+        ))}
+      </p>
+
+      {tagline && (
+        <p
+          className="text-sm text-white/45 mt-3 italic"
+          style={{ textShadow: "0 1px 8px rgba(0,0,0,0.3)" }}
+        >
+          {tagline}
+        </p>
+      )}
+
+      <p
+        className="text-[11px] text-white/30 mt-5 tracking-wide"
+        style={{ textShadow: "0 1px 6px rgba(0,0,0,0.3)" }}
+      >
+        Powered by <span className="text-white/50 font-medium">238M+</span> bike rides
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/components/weather/WeatherNarrative.tsx
+++ b/frontend/src/components/weather/WeatherNarrative.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import type { CurrentWeatherResponse, SimilarDayResponse, RecommendationResponse } from "@/lib/types";
+import type { CurrentWeatherResponse, SimilarDayResponse, RecommendationResponse, TempUnit } from "@/lib/types";
 import { formatHour12 } from "@/lib/format";
+import { useCityStore } from "@/store/useCityStore";
 
 const CITY_NAMES: Record<string, string> = {
   nyc: "New York City",
@@ -19,18 +20,23 @@ interface Props {
 function buildNarrative(
   weather: CurrentWeatherResponse,
   similarDay: SimilarDayResponse | undefined,
+  tempUnit: TempUnit,
 ): string[] {
   const cityName = CITY_NAMES[weather.city] ?? weather.city;
   const desc = weather.weather_description.toLowerCase();
   const lines: string[] = [];
 
   // Opening line — weather description
-  const temp = Math.round(weather.temperature_f);
+  const temp = Math.round(tempUnit === "fahrenheit" ? weather.temperature_f : weather.temperature_c);
+  const unit = tempUnit === "fahrenheit" ? "F" : "C";
   lines.push(
-    `It's ${desc} and ${temp}°F in ${cityName} right now.`,
+    `It's ${desc} and ${temp}°${unit} in ${cityName} right now.`,
   );
 
   // Duration insight
+  // ±5% threshold for duration qualifiers (vs ±3% for volume below) —
+  // duration has higher natural variance so we use a wider band to avoid
+  // noisy "longer/shorter" labels on unremarkable days.
   if (similarDay?.avg_duration_minutes != null) {
     const dur = Math.round(similarDay.avg_duration_minutes);
     const qualifier =
@@ -87,15 +93,19 @@ export default function WeatherNarrative({
   recommendations,
   isLoading,
 }: Props) {
+  const tempUnit = useCityStore((s) => s.tempUnit);
   const [visible, setVisible] = useState(false);
 
+  const ready = !isLoading && !!weather;
+
   useEffect(() => {
-    if (!isLoading && weather) {
-      const id = setTimeout(() => setVisible(true), 100);
-      return () => clearTimeout(id);
+    if (!ready) {
+      setVisible(false);
+      return;
     }
-    setVisible(false);
-  }, [isLoading, weather]);
+    const id = setTimeout(() => setVisible(true), 100);
+    return () => clearTimeout(id);
+  }, [ready]);
 
   if (isLoading || !weather) {
     return (
@@ -109,7 +119,7 @@ export default function WeatherNarrative({
     );
   }
 
-  const lines = buildNarrative(weather, similarDay);
+  const lines = buildNarrative(weather, similarDay, tempUnit);
   const tagline = pickTagline(recommendations);
 
   return (

--- a/frontend/src/components/weather/WeatherScene.tsx
+++ b/frontend/src/components/weather/WeatherScene.tsx
@@ -45,7 +45,7 @@ export default function WeatherScene() {
   const city = useCityStore((s) => s.city);
   const period = useTimePeriod(city);
   const { data: weather, isLoading: weatherLoading } = useWeather(city);
-  const { data: insights, isLoading: insightsLoading } = useInsights(city);
+  const { data: insights } = useInsights(city);
   const { data: similarDay, isLoading: similarDayLoading } = useSimilarDay(city);
 
   const category = weather?.weather_category as WeatherCategory | undefined;

--- a/frontend/src/components/weather/WeatherScene.tsx
+++ b/frontend/src/components/weather/WeatherScene.tsx
@@ -65,7 +65,7 @@ export default function WeatherScene() {
             weather={weather}
             similarDay={similarDay}
             recommendations={insights?.recommendations}
-            isLoading={weatherLoading || similarDayLoading || insightsLoading}
+            isLoading={weatherLoading || similarDayLoading}
           />
         </div>
 

--- a/frontend/src/components/weather/WeatherScene.tsx
+++ b/frontend/src/components/weather/WeatherScene.tsx
@@ -2,7 +2,7 @@
 
 import SkyGradient from "./SkyGradient";
 import WeatherHero from "./WeatherHero";
-import BikingScore from "./BikingScore";
+import WeatherNarrative from "./WeatherNarrative";
 import CitySilhouette from "./CitySilhouette";
 import FogOverlay from "./FogOverlay";
 import CloudOverlay from "./CloudOverlay";
@@ -10,6 +10,7 @@ import SunOverlay from "./SunOverlay";
 import WeatherCanvas from "./WeatherCanvas";
 import { useWeather } from "@/hooks/useWeather";
 import { useInsights } from "@/hooks/useInsights";
+import { useSimilarDay } from "@/hooks/useSimilarDay";
 import { useTimePeriod } from "@/hooks/useTimePeriod";
 import { useCityStore } from "@/store/useCityStore";
 import { needsCanvas } from "@/lib/particles";
@@ -45,6 +46,7 @@ export default function WeatherScene() {
   const period = useTimePeriod(city);
   const { data: weather, isLoading: weatherLoading } = useWeather(city);
   const { data: insights, isLoading: insightsLoading } = useInsights(city);
+  const { data: similarDay, isLoading: similarDayLoading } = useSimilarDay(city);
 
   const category = weather?.weather_category as WeatherCategory | undefined;
 
@@ -59,16 +61,12 @@ export default function WeatherScene() {
         <div className="flex-1" />
 
         <div className="flex justify-center pb-[26vh] relative z-20">
-          <div className="flex flex-col items-center">
-            <BikingScore
-              score={insights?.biking_score}
-              recommendations={insights?.recommendations}
-              isLoading={insightsLoading}
-            />
-            <p className="text-xs text-white/40 mt-4 tracking-wide">
-              Based on <span className="text-white/60 font-medium">238M+</span> bike rides across NYC &amp; London
-            </p>
-          </div>
+          <WeatherNarrative
+            weather={weather}
+            similarDay={similarDay}
+            recommendations={insights?.recommendations}
+            isLoading={weatherLoading || similarDayLoading || insightsLoading}
+          />
         </div>
 
         <div className="absolute bottom-8 left-1/2 -translate-x-1/2 flex flex-col items-center gap-1 animate-bounce z-20">


### PR DESCRIPTION
## Summary
- Replaces the circular 0-100 BikingScore indicator in the hero section with a conversational narrative paragraph
- Narrative combines live weather, similar-day ride durations, volume trends, and peak activity hours into flowing text
- Keeps the animated WeatherScene background fully intact
- Adds fade-in animation and skeleton loading state for the narrative block
- "Powered by 238M+ bike rides" tagline at the bottom

## What it looks like
> *It's partly cloudy and 62°F in New York City right now. On days like this, bike rides tend to last around 14 minutes. The city averages 58,400 rides in similar weather, about 12% more than average. Peak activity hits between 5 PM and 7 PM.*

## Test plan
- [ ] Verify narrative renders correctly with weather + similar-day data loaded
- [ ] Verify loading skeleton shows while data is fetching
- [ ] Verify graceful degradation when similar-day data is null (weather-only sentence)
- [ ] Check readability over animated sky backgrounds (clear, rain, snow, fog)
- [ ] Test both NYC and London city selections

🤖 Generated with [Claude Code](https://claude.com/claude-code)