### PR TITLE
fix: add security headers middleware (fixes #79)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - **SQL Injection in LIMIT Clause** - Parameterized the LIMIT clause in station-performance query (`api/routes/analytics.py`) — was built via f-string interpolation, now uses DuckDB `$5` placeholder
 - **DuckDB Table Name Allowlisting** - Added `ALLOWED_PARQUETS` allowlist to `api/dependencies.py` so `parquet_path()` and `parquet_exists()` reject unknown filenames. Added `_validate_identifier()` to `db_duckdb/operations.py` for SQL identifier validation in quality-check queries. Defense-in-depth against path traversal and SQL injection via table/column names.
+- **Security Headers Middleware** - Added `SecurityHeadersMiddleware` to `api/main.py` setting X-Content-Type-Options, X-Frame-Options, Referrer-Policy, X-XSS-Protection, and Content-Security-Policy on all responses. HSTS enabled only in Railway (production) environments.
 
 ### Added
 - **Deployment Infrastructure — Phase 06** - API Dockerfile (`python:3.11-slim`), Railway service config (`railway-api.toml`), and 3 GitHub Actions CI/CD workflows: `frontend-ci.yml` (lint + type-check + build), `api-ci.yml` (pytest), `data-refresh.yml` (monthly API redeploy cron)

--- a/api/main.py
+++ b/api/main.py
@@ -9,12 +9,33 @@ import logging
 import os
 from contextlib import asynccontextmanager
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import Response
 
 from api.routes import weather, insights, similar_day, analytics
 
 logger = logging.getLogger(__name__)
+
+
+class SecurityHeadersMiddleware(BaseHTTPMiddleware):
+    """Add standard security headers to all responses."""
+
+    async def dispatch(self, request: Request, call_next) -> Response:
+        response = await call_next(request)
+        response.headers["X-Content-Type-Options"] = "nosniff"
+        response.headers["X-Frame-Options"] = "DENY"
+        response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+        response.headers["X-XSS-Protection"] = "0"
+        response.headers["Content-Security-Policy"] = (
+            "default-src 'none'; frame-ancestors 'none'"
+        )
+        if os.getenv("RAILWAY_ENVIRONMENT"):
+            response.headers["Strict-Transport-Security"] = (
+                "max-age=63072000; includeSubDomains"
+            )
+        return response
 
 
 @asynccontextmanager
@@ -44,6 +65,9 @@ app.add_middleware(
     allow_methods=["GET"],
     allow_headers=["*"],
 )
+
+# Security headers
+app.add_middleware(SecurityHeadersMiddleware)
 
 # Mount routers
 app.include_router(weather.router)


### PR DESCRIPTION
## Summary
- Added `SecurityHeadersMiddleware` to `api/main.py` that sets standard security headers on all responses
- Headers: X-Content-Type-Options (nosniff), X-Frame-Options (DENY), Referrer-Policy, X-XSS-Protection, Content-Security-Policy (default-src 'none')
- HSTS only enabled in production (checks `RAILWAY_ENVIRONMENT` env var) to avoid local dev issues

## Test plan
- [x] Existing test suite passes (249 passed)
- [ ] Manual: `curl -I` any endpoint and verify security headers are present
- [ ] Manual: verify HSTS header absent in local dev, present when `RAILWAY_ENVIRONMENT` is set

### CHANGELOG
- Added entry under `[Unreleased] > Fixed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)