### PR TITLE
chore: gitignore fleet bot telemetry droppings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,9 @@ frontend/node_modules/
 frontend/.next/
 frontend/out/
 frontend/.env.local
+# Claude fleet bot telemetry — supervision hooks may write these relative to
+# the session cwd instead of the bot directory (Claudfather/Claudlobby#874);
+# they can land at any depth and are never product data.
+**/data/events/fleet-*.jsonl
+**/data/.last-tool-call
+**/data/.idle

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+- **Ignore Claude fleet bot telemetry paths** - Narrow any-depth `.gitignore` rules for `data/events/fleet-*.jsonl`, `data/.last-tool-call`, `data/.idle`: the files Claudlobby supervision hooks can write relative to the session cwd when the bot environment is absent (Claudfather/Claudlobby#874). Prevents a broad `git add` in an agent checkout from staging fleet telemetry into this public repo; product `data/` paths are unaffected.
+
 ### Added
 - **Full System Review & Tech-Debt Triage (2026-07-02)** - Consolidated tracker at `documentation/planning/full-system-review-2026-07-02.md` cataloguing 87 new findings (12 high / 45 medium / 30 low) across the API backend, data pipeline, dbt project, frontend, and CI/infra. Highlights: silent failure masking in the orchestrator/verification layers, a real-time-weather timezone mismatch that corrupts "days like today" insights, mis-aggregated `mart_similar_day_stats` daily totals, and the absence of pipeline/dbt CI. The document also indexes the existing ~60 open GitHub issues by area for a single-source-of-truth backlog.
 - **Full System Review — Issue Filing Plan** - Companion artifact `documentation/planning/full-system-review-2026-07-02-issue-plan.md` recording the P0–P4 + nice-to-have prioritization of all 87 findings and their filed GitHub issues. P0 (#125–#132) and P1 (#133–#141) were filed as individual issues; P2 (#142–#145), P3 (#146–#148), P4 (#149), and nice-to-haves (#150) were filed as clustered, per-subsystem tracking issues with checklists.


### PR DESCRIPTION
## Why

Claudlobby supervision hooks can write session telemetry relative to the session's working directory instead of the bot's own directory when the bot environment is absent from the hook env (Claudfather/Claudlobby#874). Fleet bots regularly run sessions inside checkouts of this repo, so untracked telemetry files accumulate in working trees — and one broad `git add -A` would commit fleet telemetry into a public repo. Observed landings include nested paths (`landing/data/events/` in one storydump checkout), so the rules match at any depth.

This is **defence-in-depth behind #874** (which fixes the writer), not the fix itself: with these rules, the checkout stays safe regardless of hook behavior.

## What

Three narrow ignore rules for the exact filenames the hooks write — deliberately not a directory-level `data/` ignore, so product data paths are unaffected. Plus a CHANGELOG entry.

## Verification

`git check-ignore -v` on root, nested, and dotfile probe paths — all four bind to the new rules:

```
.gitignore:76:**/data/events/fleet-*.jsonl	data/events/fleet-9999-01-01.jsonl
.gitignore:76:**/data/events/fleet-*.jsonl	sub/dir/data/events/fleet-9999-01-01.jsonl
.gitignore:77:**/data/.last-tool-call	data/.last-tool-call
.gitignore:78:**/data/.idle	sub/data/.idle
```

- `git ls-files -ci --exclude-standard` → **0** files (no previously-tracked file becomes ignored)
- Repo history scanned across all remote refs after a fresh `git fetch --prune`: **zero** telemetry files ever committed (`git log --remotes --diff-filter=ACR` over `*fleet-*.jsonl`, `*data/.last-tool-call`, `*data/.idle`)

Part of the fleet-wide telemetry-exposure sweep (task t-1785366988-c85c); one PR per affected repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RggBvjM8p4ngzR8xzDrTVr
